### PR TITLE
Add Azure OpenAI content filters (RAI policies) to deployment

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -27,6 +27,7 @@ param resourceGroupName string = ''
 param openAiServiceName string = ''
 param apimIdentityName string = ''
 param chargeBackIdentityName string = ''
+param deploymentScriptIdentityName string = ''
 param apimServiceName string = ''
 param logAnalyticsName string = ''
 param dataCollectionEndpointName string = ''
@@ -110,6 +111,16 @@ module managedIdentityChargeBack './modules/security/managed-identity.bicep' = {
   scope: resourceGroup
   params: {
     name: !empty(chargeBackIdentityName) ? chargeBackIdentityName : '${abbrs.managedIdentityUserAssignedIdentities}${resourceToken}-cb'
+    location: location
+    tags: tags
+  }
+}
+
+module managedIdentityDeploymentScript './modules/security/managed-identity.bicep' = {
+  name: 'managed-identity-deployment-script'
+  scope: resourceGroup
+  params: {
+    name: !empty(deploymentScriptIdentityName) ? deploymentScriptIdentityName : '${abbrs.managedIdentityUserAssignedIdentities}${resourceToken}-cb'
     location: location
     tags: tags
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -208,6 +208,7 @@ module openAi './modules/ai/cognitiveservices.bicep' = {
     location: location
     tags: tags
     chargeBackManagedIdentityName: managedIdentityChargeBack.outputs.managedIdentityName
+    deploymentScriptIdentityName: managedIdentityDeploymentScript.outputs.managedIdentityName
     logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
     sku: {
       name: openAiSkuName
@@ -249,6 +250,7 @@ module openAiSecondary './modules/ai/cognitiveservices.bicep' = if (secondaryOpe
     privateEndpointLocation: location
     tags: tags
     chargeBackManagedIdentityName: managedIdentityChargeBack.outputs.managedIdentityName
+    deploymentScriptIdentityName: managedIdentityDeploymentScript.outputs.managedIdentityName
     logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
     sku: {
       name: openAiSkuName

--- a/infra/modules/ai/cognitiveservices.bicep
+++ b/infra/modules/ai/cognitiveservices.bicep
@@ -14,6 +14,7 @@ param sku object = {
 //param apimManagedIdentityName string
 param chargeBackManagedIdentityName string
 param logAnalyticsWorkspaceId string
+param deploymentScriptIdentityName string
 
 //Private Endpoint settings
 param openAiPrivateEndpointName string
@@ -66,7 +67,7 @@ param raiPolicies array = [
 ]
 
 resource managedIdentityDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' existing = {
-  name: 'DeploymentScriptManagedIdentity'
+  name: deploymentScriptIdentityName
 }
 
 resource roleAssignmentDeploymentScript 'Microsoft.Authorization/roleAssignments@2022-04-01' = {

--- a/infra/modules/ai/cognitiveservices.bicep
+++ b/infra/modules/ai/cognitiveservices.bicep
@@ -25,6 +25,9 @@ param openAiDnsZoneName string
 // Cognitive Services OpenAI User
 var roleDefinitionResourceId = '/providers/Microsoft.Authorization/roleDefinitions/5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
 
+// Cognitive Services OpenAI Contributor
+var roleDefinitionDeploymentScriptResourceId = '/providers/Microsoft.Authorization/roleDefinitions/a001fd3d-188f-4b5d-821b-7da978bf7442'
+
 // resource managedIdentityApim 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' existing = {
 //   name: apimManagedIdentityName
 // }
@@ -68,9 +71,9 @@ resource managedIdentityDeploymentScript 'Microsoft.ManagedIdentity/userAssigned
 
 resource roleAssignmentDeploymentScript 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: account
-  name: guid(managedIdentityDeploymentScript.id, roleDefinitionResourceId)
+  name: guid(managedIdentityDeploymentScript.id, roleDefinitionDeploymentScriptResourceId)
   properties: {
-    roleDefinitionId: roleDefinitionResourceId
+    roleDefinitionId: roleDefinitionDeploymentScriptResourceId
     principalId: managedIdentityDeploymentScript.properties.principalId
     principalType: 'ServicePrincipal'
   }

--- a/infra/modules/ai/rai-policies/default-with-jailbreak-detection.json
+++ b/infra/modules/ai/rai-policies/default-with-jailbreak-detection.json
@@ -1,0 +1,93 @@
+{
+    "name": "default-policy",
+    "displayName": "Default Enterprise Policy (including jailbreak detection)",
+    "properties": {
+        "basePolicyName": "Microsoft.Default",
+        "type": "UserManaged",
+        "contentFilters": [
+            {
+                "name": "hate",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "prompt"
+            },
+            {
+                "name": "sexual",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "prompt"
+            },
+            {
+                "name": "selfharm",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "prompt"
+            },
+            {
+                "name": "violence",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "prompt"
+            },
+            {
+                "name": "hate",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "completion"
+            },
+            {
+                "name": "sexual",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "completion"
+            },
+            {
+                "name": "selfharm",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "completion"
+            },
+            {
+                "name": "violence",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "completion"
+            },
+            {
+                "name": "jailbreak",
+                "blocking": true,
+                "source": "prompt",
+                "enabled": true
+            },
+            {
+                "name": "protected_material_text",
+                "blocking": false,
+                "source": "completion",
+                "enabled": true
+            },
+            {
+                "name": "protected_material_code",
+                "blocking": false,
+                "source": "completion",
+                "enabled": true
+            },
+            {
+                "name": "profanity",
+                "blocking": false,
+                "source": "completion",
+                "enabled": false
+            }
+        ],
+        "completionBlocklists": [],
+        "promptBlocklists": [],
+        "mode": "default"
+    }
+}

--- a/infra/modules/ai/rai-policies/low-filtering-policy.json
+++ b/infra/modules/ai/rai-policies/low-filtering-policy.json
@@ -1,0 +1,93 @@
+{
+    "name": "low-filtering-policy",
+    "displayName": "Policy which only blocks low severity content",
+    "properties": {
+        "basePolicyName": "Microsoft.Default",
+        "type": "UserManaged",
+        "contentFilters": [
+            {
+                "name": "hate",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "prompt"
+            },
+            {
+                "name": "sexual",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "prompt"
+            },
+            {
+                "name": "selfharm",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "prompt"
+            },
+            {
+                "name": "violence",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "prompt"
+            },
+            {
+                "name": "hate",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "completion"
+            },
+            {
+                "name": "sexual",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "completion"
+            },
+            {
+                "name": "selfharm",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "completion"
+            },
+            {
+                "name": "violence",
+                "blocking": true,
+                "enabled": true,
+                "allowedContentLevel": "medium",
+                "source": "completion"
+            },
+            {
+                "name": "jailbreak",
+                "blocking": true,
+                "source": "prompt",
+                "enabled": true
+            },
+            {
+                "name": "protected_material_text",
+                "blocking": false,
+                "source": "completion",
+                "enabled": true
+            },
+            {
+                "name": "protected_material_code",
+                "blocking": false,
+                "source": "completion",
+                "enabled": true
+            },
+            {
+                "name": "profanity",
+                "blocking": false,
+                "source": "completion",
+                "enabled": false
+            }
+        ],
+        "completionBlocklists": [],
+        "promptBlocklists": [],
+        "mode": "default"
+    }
+}


### PR DESCRIPTION
This pull request adds a custom content filter to the Azure OpenAI resource. For enterprise use, customers would like to apply certain content filters (e.g. jailbreak detection) and deploy + enable this for certain model deployments via code.

**TODO**
- [x] Fix the deployment script to use the right identity
- [ ] Create an extra model deployment with a content filter assigned
- [x] Fix issue where JSON file cannot be loaded