### PR TITLE
Removed string concatenations from hotpath

### DIFF
--- a/src/dotnet/AzureAI.Proxy/ReverseProxy/OpenAIChargebackTransformProvider.cs
+++ b/src/dotnet/AzureAI.Proxy/ReverseProxy/OpenAIChargebackTransformProvider.cs
@@ -59,8 +59,8 @@ internal class OpenAIChargebackTransformProvider : ITransformProvider
         });
         context.AddResponseTransform(async responseContext =>
         {
-            var originalStream = await responseContext.ProxyResponse.Content.ReadAsStreamAsync();
-            string capturedBody = "";
+            var originalStream = await responseContext.ProxyResponse.Content.ReadAsStreamAsync();                        
+            var stringBuilder = new StringBuilder();
 
             // Buffer for reading chunks
             byte[] buffer = new byte[8192];
@@ -72,7 +72,7 @@ internal class OpenAIChargebackTransformProvider : ITransformProvider
                 // Convert the chunk to a string for inspection
                 var chunk = Encoding.UTF8.GetString(buffer, 0, bytesRead);
 
-                capturedBody += chunk;
+                stringBuilder.Append(chunk);
 
                 // Write the unmodified chunk back to the response
                 await responseContext.HttpContext.Response.Body.WriteAsync(buffer, 0, bytesRead);
@@ -95,6 +95,7 @@ internal class OpenAIChargebackTransformProvider : ITransformProvider
             }
            
             bool firstChunck = true;
+            var capturedBody = stringBuilder.ToString();
             var chunks = capturedBody.Split("data:");
             foreach (var chunk in chunks)
             {


### PR DESCRIPTION
Having string concats on a hot-path would significantly harm performance due to fast memory allocations and GC will suffer. 