### PR TITLE
Remove postdown hook

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -25,8 +25,3 @@ hooks:
     windows:
       shell: pwsh
       run: ./scripts/set-env.ps1
-#   postdown: 
-#       shell: sh
-#       run: az apim deletedservice purge --location ${AZURE_LOCATION} --service-name ${APIM_NAME}
-#       interactive: true
-    


### PR DESCRIPTION
Not required anymore, due to the new documentation and azd down asking to purge resources out of the box.