### PR TITLE
APIM Fix deploys stv2 compute platform now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,5 +410,24 @@ FodyWeavers.xsd
 # Local Test scripts
 local.tests.http
 
-# src development files, cleanup needed
+# Azurechat / Node.js with Next
+# next.js
+**/.next/
+**/out/
+
+# production
+**/build
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env*.local
+.env
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -187,11 +187,23 @@ module monitoring './modules/monitor/monitoring.bicep' = {
 }
 
 
+var apimService = !empty(apimServiceName) ? apimServiceName : '${abbrs.apiManagementService}${resourceToken}'
+module apimPip 'modules/networking/publicip.bicep' = {
+  name: 'apim-pip'
+  scope: resourceGroup
+  params: {
+    name: '${apimService}-pip'
+    location: location
+    tags: tags
+    fqdn:'${apimService}.${location}.cloudapp.azure.com'
+  }
+}
+
 module apim './modules/apim/apim.bicep' = {
   name: 'apim'
   scope: resourceGroup
   params: {
-    name: !empty(apimServiceName) ? apimServiceName : '${abbrs.apiManagementService}${resourceToken}'
+    name: apimService
     location: location
     tags: tags
     sku: apimSku

--- a/infra/modules/apim/apim.bicep
+++ b/infra/modules/apim/apim.bicep
@@ -47,7 +47,7 @@ resource apimService 'Microsoft.ApiManagement/service@2023-03-01-preview' = {
     publisherEmail: publisherEmail
     publisherName: publisherName
     virtualNetworkType: virtualNetworkType
-    publicIpAddressId: (virtualNetworkType == 'External') ? apimPublicIp.id : null
+    publicIpAddressId: apimPublicIp.id 
     virtualNetworkConfiguration: {
       subnetResourceId: apimSubnetId
     }

--- a/infra/modules/apim/apim.bicep
+++ b/infra/modules/apim/apim.bicep
@@ -15,12 +15,18 @@ param apimManagedIdentityName string
 param apimSubnetId string
 param virtualNetworkType string
 
+
 resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = {
   name: applicationInsightsName
 }
 
 resource managedIdentityApim 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' existing = {
   name: apimManagedIdentityName
+}
+
+//setting explicit public IP for APIM will force stV2 instance of APIM
+resource apimPublicIp 'Microsoft.Network/publicIPAddresses@2023-04-01' existing = {
+  name: '${name}-pip'
 }
 
 resource apimService 'Microsoft.ApiManagement/service@2023-03-01-preview' = {
@@ -41,6 +47,7 @@ resource apimService 'Microsoft.ApiManagement/service@2023-03-01-preview' = {
     publisherEmail: publisherEmail
     publisherName: publisherName
     virtualNetworkType: virtualNetworkType
+    publicIpAddressId: (virtualNetworkType == 'External') ? apimPublicIp.id : null
     virtualNetworkConfiguration: {
       subnetResourceId: apimSubnetId
     }
@@ -61,6 +68,7 @@ resource apimService 'Microsoft.ApiManagement/service@2023-03-01-preview' = {
       'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Tls11': 'false'
       'Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Backend.Protocols.Ssl30': 'false'
     }
+    
   }
 }
 
@@ -101,3 +109,4 @@ resource apimLogger 'Microsoft.ApiManagement/service/loggers@2021-12-01-preview'
 }
 
 output apimName string = apimService.name
+output apimEndpoint string = apimService.properties.gatewayUrl

--- a/infra/modules/networking/publicip.bicep
+++ b/infra/modules/networking/publicip.bicep
@@ -1,0 +1,28 @@
+param name string 
+param location string
+param tags object = {}
+param fqdn string
+
+
+resource publicIp 'Microsoft.Network/publicIPAddresses@2023-04-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  zones: [
+    '1'
+    '2'
+    '3'
+  ]
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+    dnsSettings: {
+      domainNameLabel: name
+      fqdn: fqdn 
+    }
+  }
+}


### PR DESCRIPTION
By introducing an explicit public IP APIM deploys in stv2 compute model
Needed because stv1 is almost EOL
You will have to reprovision APIM - so new AZD UP in a fresh environment