### PR TITLE
Add OpenAI Marketing Limited product and subscription - this is to li…

### DIFF
--- a/infra/modules/apim/apim-backend.bicep
+++ b/infra/modules/apim/apim-backend.bicep
@@ -49,6 +49,47 @@ resource apimProxyApi 'Microsoft.ApiManagement/service/apis@2023-03-01-preview' 
   }
 }
 
+resource openAiMarketingLimitedProduct 'Microsoft.ApiManagement/service/products@2022-08-01' = {
+  parent: apimService
+  name: 'openAiMarketingLimited'
+  properties: {
+    displayName: 'Marketing OpenAI Limited'
+    description: 'Marketing team must subscribe for this Product to use the OpenAI API. They are limited to specific versions of the OpenAI API models. This is handled by Product specific Policies on APIM.'
+    approvalRequired: false
+    subscriptionRequired: true
+    state: 'published'
+  }
+}
+
+resource openAiMarketingLimitedProductPolicy 'Microsoft.ApiManagement/service/products/policies@2020-12-01' = {
+  name: 'policy'
+  parent: openAiMarketingLimitedProduct
+  properties: {
+    value: loadTextContent('./policies/product_policy_model_limit.xml')
+    format: 'rawxml'
+  }
+}
+
+resource openAiProductLink 'Microsoft.ApiManagement/service/products/apiLinks@2023-03-01-preview' = {
+  name: 'openai-product-apilink'
+  parent: openAiMarketingLimitedProduct
+  properties: {
+    apiId: apimProxyApi.id
+  }
+}
+
+resource productSubscription 'Microsoft.ApiManagement/service/subscriptions@2021-04-01-preview' = {
+  name: 'MarketingProductSubscription'
+  parent: apimService
+  properties: {
+    displayName: 'Marketing OpenAI Product Subscription'
+    scope: '/products/${openAiMarketingLimitedProduct.id}'
+    state: 'active'
+    allowTracing: true
+  }
+}
+
+
 resource proxyApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2023-03-01-preview' = {
   name: 'policy'
   parent: apimProxyApi

--- a/infra/modules/apim/apim-backend.bicep
+++ b/infra/modules/apim/apim-backend.bicep
@@ -49,21 +49,21 @@ resource apimProxyApi 'Microsoft.ApiManagement/service/apis@2023-03-01-preview' 
   }
 }
 
-resource openAiMarketingLimitedProduct 'Microsoft.ApiManagement/service/products@2022-08-01' = {
+resource openAiGpt35TurboProduct 'Microsoft.ApiManagement/service/products@2022-08-01' = {
   parent: apimService
-  name: 'openAiMarketingLimited'
+  name: 'openAiGpt35TurboProduct'
   properties: {
-    displayName: 'Marketing OpenAI Limited'
-    description: 'Marketing team must subscribe for this Product to use the OpenAI API. They are limited to specific versions of the OpenAI API models. This is handled by Product specific Policies on APIM.'
+    displayName: 'Gpt-35-Turbo'
+    description: 'Open AI model Gpt-35-Turbo.'
     approvalRequired: false
     subscriptionRequired: true
     state: 'published'
   }
 }
 
-resource openAiMarketingLimitedProductPolicy 'Microsoft.ApiManagement/service/products/policies@2020-12-01' = {
+resource openAiGpt35TurboProductPolicy 'Microsoft.ApiManagement/service/products/policies@2020-12-01' = {
   name: 'policy'
-  parent: openAiMarketingLimitedProduct
+  parent: openAiGpt35TurboProduct
   properties: {
     value: loadTextContent('./policies/product_policy_model_limit.xml')
     format: 'rawxml'
@@ -72,18 +72,18 @@ resource openAiMarketingLimitedProductPolicy 'Microsoft.ApiManagement/service/pr
 
 resource openAiProductLink 'Microsoft.ApiManagement/service/products/apiLinks@2023-03-01-preview' = {
   name: 'openai-product-apilink'
-  parent: openAiMarketingLimitedProduct
+  parent: openAiGpt35TurboProduct
   properties: {
     apiId: apimProxyApi.id
   }
 }
 
 resource productSubscription 'Microsoft.ApiManagement/service/subscriptions@2021-04-01-preview' = {
-  name: 'MarketingProductSubscription'
+  name: 'gpt35TurboProductSubscription'
   parent: apimService
   properties: {
-    displayName: 'Marketing OpenAI Product Subscription'
-    scope: '/products/${openAiMarketingLimitedProduct.id}'
+    displayName: 'Gtp-35-Turbo Subscription'
+    scope: '/products/${openAiGpt35TurboProduct.id}'
     state: 'active'
     allowTracing: true
   }

--- a/infra/modules/apim/policies/product_policy_model_limit.xml
+++ b/infra/modules/apim/policies/product_policy_model_limit.xml
@@ -1,0 +1,21 @@
+<policies>
+    <inbound>
+        <base />
+        <choose>
+            <when condition="@(!(Convert.ToString(context.Request.MatchedParameters["deployment-id"])??"").Equals("gpt-turbo-3.5"))">
+                <return-response>
+                    <set-status code="403" reason="Not Authorized" />
+                </return-response>
+            </when>
+        </choose>
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>


### PR DESCRIPTION
This pull request primarily introduces a new product `openAiMarketingLimitedProduct` in the `apim-backend.bicep` file and sets up related resources and policies. It also adds a policy in the `product_policy_model_limit.xml` file that restricts access based on the `deployment-id`.

Here are the key changes:

New resources in `apim-backend.bicep`:

* [`resource openAiMarketingLimitedProduct 'Microsoft.ApiManagement/service/products@2022-08-01'`](diffhunk://#diff-adc402b2c50021b8adebc740931dc5e8c5794a27b5c151d562fe255ca6b64c22R52-R92): This new product named 'openAiMarketingLimited' is created for the Marketing team to use the OpenAI API. The product is published, does not require approval but requires subscription.

* [`resource openAiMarketingLimitedProductPolicy 'Microsoft.ApiManagement/service/products/policies@2020-12-01'`](diffhunk://#diff-adc402b2c50021b8adebc740931dc5e8c5794a27b5c151d562fe255ca6b64c22R52-R92): This policy is linked to the `openAiMarketingLimitedProduct` and it loads its value from the `product_policy_model_limit.xml` file.

* [`resource openAiProductLink 'Microsoft.ApiManagement/service/products/apiLinks@2023-03-01-preview'`](diffhunk://#diff-adc402b2c50021b8adebc740931dc5e8c5794a27b5c151d562fe255ca6b64c22R52-R92): This resource links the `openAiMarketingLimitedProduct` to the `apimProxyApi`.

* [`resource productSubscription 'Microsoft.ApiManagement/service/subscriptions@2021-04-01-preview'`](diffhunk://#diff-adc402b2c50021b8adebc740931dc5e8c5794a27b5c151d562fe255ca6b64c22R52-R92): This resource sets up a subscription named 'MarketingProductSubscription' for the `openAiMarketingLimitedProduct`.

Policy changes in `product_policy_model_limit.xml`:

* A new policy is added that restricts access based on the `deployment-id`. If the `deployment-id` does not match 'gpt-turbo-3.5', a 'Not Authorized' response is returned.